### PR TITLE
fix: move Sentry config to client/server config files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,11 @@
 # Get this from your Buttondown account settings → API
 BUTTONDOWN_API_KEY=
 
-# Get this from your Sentry project settings → Client Keys (DSN)
+# Get this from your Sentry project settings → Client Keys (DSN).
+# SENTRY_DSN is used server-side (Node/SSR). PUBLIC_SENTRY_DSN is the same
+# value but prefixed PUBLIC_ so Astro exposes it to the browser bundle.
 SENTRY_DSN=
+PUBLIC_SENTRY_DSN=
 
 # Get this from your Sentry account settings → Auth Tokens (needed for source maps)
 SENTRY_AUTH_TOKEN=

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,9 +14,11 @@ export default defineConfig({
     react(),
     mdx(),
     // Sentry monitors errors on both server and client.
-    // DSN is read from the SENTRY_DSN environment variable.
+    // DSN is now set in src/sentry.client.config.ts and src/sentry.server.config.ts
+    // (passing dsn directly here is deprecated).
+    // sourceMapsUploadOptions stays here because it controls the build-time
+    // source map upload step, not the runtime SDK.
     sentry({
-      dsn: import.meta.env.SENTRY_DSN,
       sourceMapsUploadOptions: {
         project: "internal-transit",
         authToken: import.meta.env.SENTRY_AUTH_TOKEN,

--- a/src/sentry.client.config.ts
+++ b/src/sentry.client.config.ts
@@ -1,0 +1,11 @@
+// Client-side Sentry initialization — runs in the browser.
+// In Astro, environment variables must be prefixed with PUBLIC_ to be
+// exposed to the browser. This file is picked up automatically by the
+// @sentry/astro integration at build time.
+import * as Sentry from "@sentry/astro";
+
+Sentry.init({
+  // PUBLIC_SENTRY_DSN is the browser-safe copy of your DSN.
+  // Set it in .env (and in your Vercel project environment variables).
+  dsn: import.meta.env.PUBLIC_SENTRY_DSN,
+});

--- a/src/sentry.server.config.ts
+++ b/src/sentry.server.config.ts
@@ -1,0 +1,11 @@
+// Server-side Sentry initialization — runs in Node (SSR / API routes).
+// Server environment variables do NOT need the PUBLIC_ prefix because
+// they are never sent to the browser. This file is picked up automatically
+// by the @sentry/astro integration at build time.
+import * as Sentry from "@sentry/astro";
+
+Sentry.init({
+  // SENTRY_DSN is your private DSN, kept server-side only.
+  // Set it in .env (and in your Vercel project environment variables).
+  dsn: import.meta.env.SENTRY_DSN,
+});


### PR DESCRIPTION
Closes #18