### PR TITLE
Add project case-study pages

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -20,11 +20,11 @@ const blog = defineCollection({
   }),
 });
 
-// Projects collection — feeds the home page "Work" list. Data-only, no
-// per-project pages. JSON rather than Markdown since there's no long-form
-// body content, just structured fields.
+// Projects collection — feeds the home page "Work" list AND individual
+// case-study pages at /projects/[slug]. MDX rather than JSON since finished
+// case studies carry a long-form body, not just structured list fields.
 const projects = defineCollection({
-  loader: glob({ pattern: "**/*.json", base: "./src/content/projects" }),
+  loader: glob({ pattern: "**/*.mdx", base: "./src/content/projects" }),
   schema: z.object({
     name: z.string(),
     tagline: z.string(),
@@ -35,6 +35,23 @@ const projects = defineCollection({
     // Badge background color; omitted for the one plain-icon row.
     badgeColor: z.string().optional(),
     order: z.number().default(0),
+
+    // --- Case-study page only — all optional so a project can appear in the
+    // home page list before its case-study page is written. ---
+    // Longer dek paragraph shown on the case-study page; falls back to
+    // `tagline` when omitted, since the home-page-list tagline is often too
+    // short to work as full intro copy.
+    description: z.string().optional(),
+    // Substring of `description` (or `tagline`, as a fallback) to render
+    // italicized in the project's own `iconColor` — same technique as the
+    // blog's `accentWord`, just colored per-project instead of by category.
+    accentPhrase: z.string().optional(),
+    // Loom share URL, e.g. https://www.loom.com/share/<id>.
+    loomUrl: z.string().url().optional(),
+    embedCaption: z.string().optional(),
+    // Whether the case-study page is finished and should be linked to from
+    // the home page list. Stub projects stay `false` until written.
+    published: z.boolean().default(false),
   }),
 });
 

--- a/src/content/projects/backpanel.json
+++ b/src/content/projects/backpanel.json
@@ -1,8 +1,0 @@
-{
-  "name": "Project Backpanel",
-  "tagline": "Everything in it's place",
-  "icon": "DashboardSquare01Icon",
-  "iconColor": "#558BF6",
-  "badgeColor": "#558BF620",
-  "order": 3
-}

--- a/src/content/projects/backpanel.mdx
+++ b/src/content/projects/backpanel.mdx
@@ -1,0 +1,11 @@
+---
+name: Project Backpanel
+tagline: Everything in it's place
+icon: DashboardSquare01Icon
+iconColor: "#558BF6"
+badgeColor: "#558BF620"
+order: 3
+published: false
+---
+
+Case study coming soon.

--- a/src/content/projects/compass.json
+++ b/src/content/projects/compass.json
@@ -1,8 +1,0 @@
-{
-  "name": "Project Compass",
-  "tagline": "A new way to navigate",
-  "icon": "CompassIcon",
-  "iconColor": "#7669FC",
-  "badgeColor": "#7669FC20",
-  "order": 5
-}

--- a/src/content/projects/compass.mdx
+++ b/src/content/projects/compass.mdx
@@ -1,0 +1,11 @@
+---
+name: Project Compass
+tagline: A new way to navigate
+icon: CompassIcon
+iconColor: "#7669FC"
+badgeColor: "#7669FC20"
+order: 5
+published: false
+---
+
+Case study coming soon.

--- a/src/content/projects/config-and-conquer.json
+++ b/src/content/projects/config-and-conquer.json
@@ -1,8 +1,0 @@
-{
-  "name": "Project Config & Conquer",
-  "tagline": "Making the complex easy",
-  "icon": "Settings02Icon",
-  "iconColor": "#FF971A",
-  "badgeColor": "#FF971A20",
-  "order": 4
-}

--- a/src/content/projects/config-and-conquer.mdx
+++ b/src/content/projects/config-and-conquer.mdx
@@ -1,0 +1,11 @@
+---
+name: Project Config & Conquer
+tagline: Making the complex easy
+icon: Settings02Icon
+iconColor: "#FF971A"
+badgeColor: "#FF971A20"
+order: 4
+published: false
+---
+
+Case study coming soon.

--- a/src/content/projects/ping.json
+++ b/src/content/projects/ping.json
@@ -1,8 +1,0 @@
-{
-  "name": "Project Ping",
-  "tagline": "Rethinking how users know what's going on",
-  "icon": "BellDotIcon",
-  "iconColor": "#E34F4F",
-  "badgeColor": "#E34F4F20",
-  "order": 1
-}

--- a/src/content/projects/ping.mdx
+++ b/src/content/projects/ping.mdx
@@ -1,0 +1,19 @@
+---
+name: Project Ping
+tagline: Rethinking how users know what's going on
+icon: BellDotIcon
+iconColor: "#E34F4F"
+badgeColor: "#E34F4F20"
+order: 1
+description: Our app had a persistent problem of user awareness that originated with how we told them what was happening with their services. So we remade it from the ground up.
+accentPhrase: "what's going on"
+# TODO: replace with the real Loom share URL for this project before setting
+# published to true — the embed won't render without it.
+loomUrl: "https://www.loom.com/share/TODO-replace-with-real-loom-id"
+embedCaption: Our app had a persistent problem of user awareness that originated from the core of how we told them what was happening with their services. So we remade it from the ground up.
+published: false
+---
+
+{/* TODO: replace with the real case-study write-up. */}
+
+Case study coming soon.

--- a/src/content/projects/undercurrent.json
+++ b/src/content/projects/undercurrent.json
@@ -1,8 +1,0 @@
-{
-  "name": "Project Undercurrent",
-  "tagline": "A unified experience underneath it all",
-  "icon": "SurfboardIcon",
-  "iconColor": "#2DC7FF",
-  "badgeColor": "#2DC7FF20",
-  "order": 2
-}

--- a/src/content/projects/undercurrent.mdx
+++ b/src/content/projects/undercurrent.mdx
@@ -1,0 +1,11 @@
+---
+name: Project Undercurrent
+tagline: A unified experience underneath it all
+icon: SurfboardIcon
+iconColor: "#2DC7FF"
+badgeColor: "#2DC7FF20"
+order: 2
+published: false
+---
+
+Case study coming soon.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -45,8 +45,10 @@ const { title, description = 'Cody Keisler — product designer writing about de
     <!-- RSS autodiscovery — browsers and feed readers will find this automatically -->
     <link rel="alternate" type="application/rss+xml" title="Blog RSS Feed" href="/rss.xml" />
   </head>
-  <body class="bg-portfolio-page font-mono pt-16">
-    <slot />
+  <body class="bg-portfolio-page font-mono pt-16 min-h-screen flex flex-col">
+    <div class="flex-1">
+      <slot />
+    </div>
     <Footer />
     <!-- Vercel Speed Insights — tracks real user performance data -->
     <SpeedInsights />

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -45,8 +45,8 @@ const titleAfter = accentIndex >= 0 ? title.slice(accentIndex + (accentWord?.len
         {/* Meta row: date badge + one badge per tag */}
         <div class="flex items-center gap-8 flex-wrap">
           <div class="flex items-center gap-2">
-            <span class="flex items-center justify-center size-6 rounded-md bg-portfolio-muted/15">
-              <HugeiconsIcon icon={Calendar04Icon} size={14} color="currentColor" className="text-portfolio-ink" />
+            <span class="flex items-center justify-center size-7 rounded-md bg-portfolio-muted/15">
+              <HugeiconsIcon icon={Calendar04Icon} size={16} color="currentColor" className="text-portfolio-ink" />
             </span>
             <time datetime={publishDate.toISOString()} class="font-mono text-sm text-portfolio-ink">
               {formattedDate}
@@ -58,8 +58,8 @@ const titleAfter = accentIndex >= 0 ? title.slice(accentIndex + (accentWord?.len
               if (!config) return null;
               return (
                 <div class="flex items-center gap-2">
-                  <span class={`flex items-center justify-center size-6 rounded-md ${config.bg}`}>
-                    <HugeiconsIcon icon={config.icon} size={14} color="currentColor" className={config.text} />
+                  <span class={`flex items-center justify-center size-7 rounded-md ${config.bg}`}>
+                    <HugeiconsIcon icon={config.icon} size={16} color="currentColor" className={config.text} />
                   </span>
                   <span class="font-mono text-sm text-portfolio-ink">{tag}</span>
                 </div>
@@ -100,8 +100,8 @@ const titleAfter = accentIndex >= 0 ? title.slice(accentIndex + (accentWord?.len
      attach to it — every rule here needs :global() or it silently does nothing. */
   .article-body :global(h2) {
     font-family: var(--font-plex-sans);
-    font-weight: 600;
-    font-size: 1.25rem; /* 20px */
+    font-weight: 500;
+    font-size: 1.5rem; /* 24px */
     line-height: 2.5rem; /* 40px */
     color: var(--portfolio-ink);
     margin-bottom: 1rem; /* 16px, space after a heading before its paragraph */
@@ -109,9 +109,10 @@ const titleAfter = accentIndex >= 0 ? title.slice(accentIndex + (accentWord?.len
 
   .article-body :global(p) {
     font-family: var(--font-plex-sans);
-    font-size: 1rem; /* 16px */
+    font-size: 1.125rem; /* 18px */
     line-height: 2rem; /* 32px */
-    margin-bottom: 2rem; /* 32px between sibling paragraphs */
+    margin-bottom: 2.5rem; /* 40px between sibling paragraphs */
+    font-weight: 300;
   }
 
   .article-body :global(a) {

--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -9,7 +9,7 @@ import {
 } from "@hugeicons/core-free-icons";
 ---
 
-<footer class="flex items-center justify-between gap-4 flex-wrap px-6 py-8 max-w-[1200px] mx-auto w-full">
+<footer class="flex items-center justify-between gap-4 flex-wrap px-6 pt-8 pb-6 max-w-[1200px] mx-auto w-full">
     <p class="font-plex-sans text-sm text-portfolio-muted-2 flex flex-wrap items-center gap-x-1">
         Looking for me around the web? Find me on
         <a

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -1,0 +1,148 @@
+---
+// ProjectLayout.astro — wraps an individual project's case-study page.
+// Adapted from BlogLayout.astro: swaps the date+tags meta row for a single
+// icon+eyebrow badge, and adds a Loom embed + caption section that articles
+// don't have.
+import BaseLayout from './BaseLayout.astro';
+import { HugeiconsIcon } from '@hugeicons/react';
+import type { IconSvgElement } from '@hugeicons/react';
+
+interface Props {
+  name: string;
+  tagline: string;
+  icon: IconSvgElement;
+  iconColor?: string;
+  badgeColor?: string;
+  description?: string;
+  accentPhrase?: string;
+  loomUrl?: string;
+  embedCaption?: string;
+}
+
+const {
+  name,
+  tagline,
+  icon,
+  iconColor,
+  badgeColor,
+  description,
+  accentPhrase,
+  loomUrl,
+  embedCaption,
+} = Astro.props;
+
+// Dek paragraph (the 24px intro copy under the headline) prefers the longer
+// `description`, falling back to the shorter home-page-list `tagline` when a
+// case study hasn't set one yet.
+const dek = description ?? tagline;
+
+// Same split-around-a-phrase technique as BlogLayout's accentWord, but
+// colored by the project's own iconColor rather than a shared category
+// config. Applied to `tagline` (the headline text), not `dek` — the
+// headline and the intro paragraph below it are two separate strings.
+const accentIndex = accentPhrase ? tagline.indexOf(accentPhrase) : -1;
+const taglineBefore = accentIndex >= 0 ? tagline.slice(0, accentIndex) : tagline;
+const taglineAfter = accentIndex >= 0 ? tagline.slice(accentIndex + (accentPhrase?.length ?? 0)) : '';
+
+// Loom share URLs (loom.com/share/<id>) don't render embedded — the player
+// requires the /embed/<id> path.
+const embedSrc = loomUrl?.replace('/share/', '/embed/');
+---
+
+<BaseLayout title={name} description={tagline}>
+  <main class="mx-auto max-w-[1000px] px-6 py-18">
+    <article>
+      <header class="flex flex-col gap-8 mb-12">
+        {/* Icon badge + eyebrow label — same markup as the home page's Work list rows */}
+        <div class="flex items-center gap-2">
+          <span class="flex items-center justify-center size-7 rounded-md shrink-0" style={{ backgroundColor: badgeColor }}>
+            <HugeiconsIcon icon={icon} size={16} color={iconColor} />
+          </span>
+          <p class="font-mono text-lg tracking-[-0.18px] text-portfolio-ink">{name}</p>
+        </div>
+
+        {/* Headline — accentPhrase (if set) renders italicized in the project's own iconColor */}
+        <h1 class="font-redaction text-[80px] tracking-[-2.4px] leading-[0.94] text-portfolio-ink">
+          {taglineBefore}
+          {accentIndex >= 0 && (
+            <span class="italic" style={{ color: iconColor }}>{accentPhrase}</span>
+          )}
+          {taglineAfter}
+        </h1>
+      </header>
+
+      {/* Body — same max-width and typography as the article template's body column */}
+      <div class="max-w-[800px] flex flex-col gap-10">
+        <p class="font-plex-sans text-2xl leading-10 text-portfolio-ink">
+          {dek}
+        </p>
+
+        {embedSrc && (
+          <div class="flex flex-col gap-4">
+            <div
+              class="aspect-[1008/567] rounded-xl overflow-hidden relative"
+              style={{
+                backgroundColor: '#252525',
+                boxShadow:
+                  '0px 4px 7px 0px rgba(0,0,0,0.85), 0px 1px 2px 0px rgba(0,0,0,0.5), inset 0px 0.5px 0px 0px rgba(255,255,255,0.1), inset 0px 0px 0.5px 0px rgba(255,255,255,0.3)',
+              }}
+            >
+              <iframe
+                src={embedSrc}
+                title={`${name} video walkthrough`}
+                class="absolute inset-0 size-full"
+                allow="fullscreen; picture-in-picture"
+                allowfullscreen
+                loading="lazy"
+              />
+            </div>
+            {embedCaption && (
+              <p class="font-plex-sans text-base leading-6 text-portfolio-ink">
+                {embedCaption}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Rest of the MDX body */}
+        <div class="article-body font-plex-sans text-base leading-8 text-portfolio-ink">
+          <slot />
+        </div>
+      </div>
+    </article>
+  </main>
+</BaseLayout>
+
+<style>
+  /* MDX content comes from a separately-compiled component tree (rendered via
+     <Content /> in [slug].astro), so Astro's default *scoped* styles never
+     attach to it — every rule here needs :global() or it silently does nothing.
+     Mirrors BlogLayout.astro's identical block. */
+  .article-body :global(h2) {
+    font-family: var(--font-plex-sans);
+    font-weight: 500;
+    font-size: 1.5rem; /* 24px */
+    line-height: 2.5rem; /* 40px */
+    color: var(--portfolio-ink);
+    margin-bottom: 1rem; /* 16px, space after a heading before its paragraph */
+  }
+
+  .article-body :global(p) {
+    font-family: var(--font-plex-sans);
+    font-size: 1.125rem; /* 18px */
+    line-height: 2rem; /* 32px */
+    margin-bottom: 2.5rem; /* 40px between sibling paragraphs */
+    font-weight: 300;
+  }
+
+  .article-body :global(a) {
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-skip-ink: none;
+    text-underline-position: from-font;
+  }
+
+  .article-body :global(> p:last-of-type) {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/lib/projectIconMap.ts
+++ b/src/lib/projectIconMap.ts
@@ -1,0 +1,20 @@
+import type { IconSvgElement } from "@hugeicons/react";
+import {
+  BellDotIcon,
+  SurfboardIcon,
+  DashboardSquare01Icon,
+  Settings02Icon,
+  CompassIcon,
+} from "@hugeicons/core-free-icons";
+
+// Maps each project entry's `icon` string (from its MDX frontmatter) to the
+// actual imported HugeIcons component — content collections can't hold a
+// JS/component reference, only plain data. Shared by the home page's Work
+// list and each project's case-study page.
+export const projectIconMap: Record<string, IconSvgElement> = {
+  BellDotIcon,
+  SurfboardIcon,
+  DashboardSquare01Icon,
+  Settings02Icon,
+  CompassIcon,
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,26 +2,9 @@
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { getCollection } from "astro:content";
 import { HugeiconsIcon } from "@hugeicons/react";
-import type { IconSvgElement } from "@hugeicons/react";
-import {
-    BellDotIcon,
-    SurfboardIcon,
-    DashboardSquare01Icon,
-    Settings02Icon,
-    CompassIcon,
-    Calendar04Icon,
-} from "@hugeicons/core-free-icons";
+import { Calendar04Icon } from "@hugeicons/core-free-icons";
 import { categoryConfig } from "@/lib/categoryConfig";
-
-// Maps each project entry's `icon` string (from its JSON file) to the actual
-// imported HugeIcons component — JSON can't hold a JS/component reference.
-const iconMap: Record<string, IconSvgElement> = {
-    BellDotIcon,
-    SurfboardIcon,
-    DashboardSquare01Icon,
-    Settings02Icon,
-    CompassIcon,
-};
+import { projectIconMap } from "@/lib/projectIconMap";
 
 const projects = (await getCollection("projects")).sort(
     (a, b) => a.data.order - b.data.order,
@@ -65,8 +48,8 @@ const latestPosts = (await getCollection("blog", ({ data }) => !data.draft))
             </p>
             <div class="flex flex-col gap-4 w-full">
                 {
-                    projects.map((project, index) => (
-                        <>
+                    projects.map((project, index) => {
+                        const row = (
                             <div class="flex items-center justify-between gap-4 w-full flex-wrap">
                                 <div class="flex items-center gap-3">
                                     <span
@@ -74,7 +57,7 @@ const latestPosts = (await getCollection("blog", ({ data }) => !data.draft))
                                             style={{ backgroundColor: project.data.badgeColor }}
                                         >
                                             <HugeiconsIcon
-                                                icon={iconMap[project.data.icon]}
+                                                icon={projectIconMap[project.data.icon]}
                                                 size={18}
                                                 color={project.data.iconColor}
                                             />
@@ -87,11 +70,22 @@ const latestPosts = (await getCollection("blog", ({ data }) => !data.draft))
                                     {project.data.tagline}
                                 </p>
                             </div>
-                            {index < projects.length - 1 && (
-                                <div class="h-px w-full bg-portfolio-muted-2/20" />
-                            )}
-                        </>
-                    ))
+                        );
+                        return (
+                            <>
+                                {project.data.published ? (
+                                    <a href={`/projects/${project.id}`} class="w-full">
+                                        {row}
+                                    </a>
+                                ) : (
+                                    row
+                                )}
+                                {index < projects.length - 1 && (
+                                    <div class="h-px w-full bg-portfolio-muted-2/20" />
+                                )}
+                            </>
+                        );
+                    })
                 }
             </div>
         </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,10 +35,8 @@ const latestPosts = (await getCollection("blog", ({ data }) => !data.draft))
                 <span class="text-portfolio-accent italic">experiences better
                 for people</span>
             </p>
-            <p class="font-plex-sans font-light text-xl lg:text-2xl leading-normal text-portfolio-ink">
-                Bouncing between graphic design, web design, motion design, and
-                software design has taught me what design is, what it isn't,
-                and how to use it to communicate effectively with people.
+            <p class="font-plex-sans font-medium text-md tracking-wider lg:text-lg leading-normal text-portfolio-ink whitespace-nowrap w-full">
+                Product designer from Rock Hill, SC
             </p>
         </div>
 

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,0 +1,33 @@
+---
+import ProjectLayout from '@/layouts/ProjectLayout.astro';
+import { getCollection, render } from 'astro:content';
+import { projectIconMap } from '@/lib/projectIconMap';
+
+// getStaticPaths tells Astro which pages to build at compile time.
+// One page is generated per project.
+export async function getStaticPaths() {
+  const projects = await getCollection('projects');
+  return projects.map((project) => ({
+    // Entries are addressed by .id (the filename) rather than .slug.
+    params: { slug: project.id },
+    props: { project },
+  }));
+}
+
+const { project } = Astro.props;
+const { Content } = await render(project);
+---
+
+<ProjectLayout
+  name={project.data.name}
+  tagline={project.data.tagline}
+  icon={projectIconMap[project.data.icon]}
+  iconColor={project.data.iconColor}
+  badgeColor={project.data.badgeColor}
+  description={project.data.description}
+  accentPhrase={project.data.accentPhrase}
+  loomUrl={project.data.loomUrl}
+  embedCaption={project.data.embedCaption}
+>
+  <Content />
+</ProjectLayout>


### PR DESCRIPTION
## Summary
- Adds individual case-study pages at `/projects/[slug]`, reusing the article template's structure (accent-split headline, dek, shared footer) with a new Loom embed + caption section
- Moves the `projects` content collection from data-only JSON to MDX so finished case studies can carry long-form body content; existing entries are `published: false` stubs until each case study is written
- Refreshes article/case-study body typography (larger, lighter `h2`/`p` treatment) and fixes the footer sitting short of the viewport bottom on pages with little content
- Swaps the home page bio paragraph for a shorter "Product designer from Rock Hill, SC" line

## Test plan
- [ ] `bun run build` succeeds and generates a page per project
- [ ] Visit `/projects/ping` — headline/dek/badge match the Figma design, Loom embed placeholder renders (real Loom URL still TODO in `ping.mdx`)
- [ ] Visit `/` — Work list renders all 5 projects unchanged, unpublished ones aren't linked
- [ ] Toggle light/dark theme on a project page — text follows theme, embed stays dark
- [ ] Visit `/blog/[slug]` and `/rss.xml` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)