### PR TITLE
Add Home breadcrumb nav to article and project pages

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -3,7 +3,7 @@
 // Receives the post's frontmatter and renders it above the content.
 import BaseLayout from './BaseLayout.astro';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { Calendar04Icon } from '@hugeicons/core-free-icons';
+import { Calendar04Icon, Home03Icon } from '@hugeicons/core-free-icons';
 import { categoryConfig } from '@/lib/categoryConfig';
 
 interface Props {
@@ -42,29 +42,34 @@ const titleAfter = accentIndex >= 0 ? title.slice(accentIndex + (accentWord?.len
   <main class="mx-auto max-w-[1000px] px-6 py-18">
     <article>
       <header class="flex flex-col gap-8 mb-12">
-        {/* Meta row: date badge + one badge per tag */}
-        <div class="flex items-center gap-8 flex-wrap">
-          <div class="flex items-center gap-2">
-            <span class="flex items-center justify-center size-7 rounded-md bg-portfolio-muted/15">
-              <HugeiconsIcon icon={Calendar04Icon} size={16} color="currentColor" className="text-portfolio-ink" />
+        {/* Meta row: Home breadcrumb on the left, date badge + one badge per tag on the right */}
+        <div class="flex items-center justify-between gap-8 flex-wrap">
+          <a href="/" class="flex items-center gap-2">
+            <span class="flex items-center justify-center size-7 rounded-md bg-portfolio-nav-muted/15">
+              <HugeiconsIcon icon={Home03Icon} size={16} color="currentColor" className="text-portfolio-nav-muted" />
             </span>
-            <time datetime={publishDate.toISOString()} class="font-mono text-sm text-portfolio-ink">
-              {formattedDate}
-            </time>
-          </div>
-          <div class="flex items-center gap-3 flex-wrap">
-            {tags.map((tag) => {
-              const config = categoryConfig[tag];
-              if (!config) return null;
-              return (
-                <div class="flex items-center gap-2">
-                  <span class={`flex items-center justify-center size-7 rounded-md ${config.bg}`}>
+            <span class="font-mono text-base text-portfolio-nav-muted underline">Home</span>
+          </a>
+
+          <div class="flex items-center gap-8 flex-wrap">
+            <div class="flex items-center gap-2">
+              <HugeiconsIcon icon={Calendar04Icon} size={16} color="currentColor" className="text-portfolio-ink" />
+              <time datetime={publishDate.toISOString()} class="font-mono text-sm text-portfolio-ink">
+                {formattedDate}
+              </time>
+            </div>
+            <div class="flex items-center gap-3 flex-wrap">
+              {tags.map((tag) => {
+                const config = categoryConfig[tag];
+                if (!config) return null;
+                return (
+                  <div class="flex items-center gap-2">
                     <HugeiconsIcon icon={config.icon} size={16} color="currentColor" className={config.text} />
-                  </span>
-                  <span class="font-mono text-sm text-portfolio-ink">{tag}</span>
-                </div>
-              );
-            })}
+                    <span class="font-mono text-sm text-portfolio-ink">{tag}</span>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </div>
 

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -6,6 +6,7 @@
 import BaseLayout from './BaseLayout.astro';
 import { HugeiconsIcon } from '@hugeicons/react';
 import type { IconSvgElement } from '@hugeicons/react';
+import { Home03Icon } from '@hugeicons/core-free-icons';
 
 interface Props {
   name: string;
@@ -53,12 +54,22 @@ const embedSrc = loomUrl?.replace('/share/', '/embed/');
   <main class="mx-auto max-w-[1000px] px-6 py-18">
     <article>
       <header class="flex flex-col gap-8 mb-12">
-        {/* Icon badge + eyebrow label — same markup as the home page's Work list rows */}
-        <div class="flex items-center gap-2">
-          <span class="flex items-center justify-center size-7 rounded-md shrink-0" style={{ backgroundColor: badgeColor }}>
-            <HugeiconsIcon icon={icon} size={16} color={iconColor} />
-          </span>
-          <p class="font-mono text-lg tracking-[-0.18px] text-portfolio-ink">{name}</p>
+        {/* Breadcrumb: Home badge, then the project's own icon badge + eyebrow label
+            (that project badge/label markup matches the home page's Work list rows) */}
+        <div class="flex items-center gap-4">
+          <a href="/" class="flex items-center gap-2">
+            <span class="flex items-center justify-center size-7 rounded-md bg-portfolio-nav-muted/15">
+              <HugeiconsIcon icon={Home03Icon} size={16} color="currentColor" className="text-portfolio-nav-muted" />
+            </span>
+            <span class="font-mono text-base text-portfolio-nav-muted underline">Home</span>
+          </a>
+          <span class="text-portfolio-nav-muted">•</span>
+          <div class="flex items-center gap-2">
+            <span class="flex items-center justify-center size-7 rounded-md shrink-0" style={{ backgroundColor: badgeColor }}>
+              <HugeiconsIcon icon={icon} size={16} color={iconColor} />
+            </span>
+            <p class="font-mono text-base tracking-[-0.18px] text-portfolio-ink">{name}</p>
+          </div>
         </div>
 
         {/* Headline — accentPhrase (if set) renders italicized in the project's own iconColor */}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -66,6 +66,10 @@
     /* Dedicated dim tone for the article footnotes list — not a light/dark pair,
        same value in both themes (per design). */
     --color-portfolio-footnote: var(--portfolio-footnote);
+    /* Dedicated muted tone for the header "Home" breadcrumb badge — same
+       value in both themes (per design), distinct from portfolio-muted/-2
+       which do change between light and dark. */
+    --color-portfolio-nav-muted: var(--portfolio-nav-muted);
 
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
@@ -117,6 +121,8 @@
     --portfolio-accent: #40C6B0;
     /* Same value in both themes — dedicated dim tone for the article footnotes list */
     --portfolio-footnote: #BBBBBB;
+    /* Same value in both themes — dedicated muted tone for the header "Home" badge */
+    --portfolio-nav-muted: #9CA3AF;
 
     --background: #F2EEEA;
     --foreground: #292929;
@@ -161,6 +167,7 @@
     --portfolio-muted-2: #C5BDB4;
     --portfolio-accent: #40C6B0;
     --portfolio-footnote: #BBBBBB;
+    --portfolio-nav-muted: #9CA3AF;
 
     --background: oklch(0.145 0 0);
     --foreground: oklch(0.985 0 0);


### PR DESCRIPTION
## Summary
- Adds a muted "Home" badge (house icon + underlined text) linking back to `/` in both the blog article and project case-study headers
- Articles: meta row becomes `justify-between` — Home anchors the left, existing date + tag badges move to the right
- Projects: eyebrow row becomes a full breadcrumb — `Home • [project badge] Project Name`
- New `--portfolio-nav-muted` (#9CA3AF) color token, fixed across light/dark themes, used for the Home badge's icon/background/text

## Test plan
- [ ] Visit `/blog/never-the-artist` — Home badge on the left, date/tag badges on the right, clicking Home goes to `/`
- [ ] Visit `/projects/ping` — breadcrumb reads "Home • [red badge] Project Ping", Home links to `/`
- [ ] Visit a stub project (e.g. `/projects/undercurrent`) — breadcrumb renders correctly there too
- [ ] Toggle light/dark theme on both page types — Home badge color stays consistent, rest of the page follows theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)