### PR TITLE
Harden pixelarticons Pro upgrade: explicit script instead of postinstall

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ PUBLIC_SENTRY_DSN=
 SENTRY_AUTH_TOKEN=
 
 # Get this from your pixelarticons.com purchase confirmation email or Gumroad library.
-# Runs automatically on every install (see "postinstall" script) to unlock the
-# full 4,400+ icon set — without it, only the free 564-icon tier installs.
+# Run `bun run icons:upgrade` after setting this to unlock the full 4,400+ icon
+# set locally — without it, only the free 564-icon tier installs. This is a
+# manual, explicit step (not a postinstall hook) so third-party code with
+# network access doesn't execute unattended on every install; Vercel runs the
+# same command explicitly as part of its configured Install Command.
 PIXELARTICONS_LICENSE_KEY=

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
-    "postinstall": "pixelarticons upgrade --key=$PIXELARTICONS_LICENSE_KEY"
+    "icons:upgrade": "pixelarticons upgrade --key=$PIXELARTICONS_LICENSE_KEY"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Follow-up to #47's Vercel deploy fix. A background security review flagged the `postinstall` hook added there:
  - **Credential exposure via process args**: the license key is passed as `--key=` on the command line, so it's visible in `/proc/<pid>/cmdline` and potentially build logs for the run's duration. Unavoidable given the underlying tool only accepts the key this way, but no reason to also run it unattended on every install.
  - **Supply-chain auto-exec on install**: `postinstall` ran automatically and unconditionally on every `bun install` — local, teammate machines, CI — executing third-party code with network access and no human review step.
- Renames the script from `postinstall` to `icons:upgrade`, run explicitly instead of automatically.

## Required manual step
Vercel's **Install Command** needs to be updated in the project dashboard to run the upgrade explicitly, e.g.:
```
bun install && bun run icons:upgrade
```
(Settings → Build & Development Settings → Install Command). Until that's set, Vercel builds will only get the free 564-icon tier again, since the automatic postinstall hook is gone.

## Test plan
- [x] Clean install (`rm -rf node_modules && bun install`) confirms free tier only, zero network calls to pixelarticons.com
- [x] `bun run icons:upgrade` (with `PIXELARTICONS_LICENSE_KEY` set) restores the full 4,421-icon Pro set
- [x] `bun run check` passes with 0 errors
- [x] `bun run build` completes successfully, all 8 pages generated including project pages using Pro-only icons
- [ ] Update Vercel Install Command in dashboard, then confirm next deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)