### PR TITLE
Add scroll-triggered dot-grid background to Approach section

### DIFF
--- a/src/content/projects/ping.mdx
+++ b/src/content/projects/ping.mdx
@@ -51,7 +51,7 @@ A year earlier, I had tried to modernize the experience by adapting it to that m
 
 The system wasn't built around lightweight alerts. It was built around events and account activity. Once I stopped trying to force it into a conventional notification UI, the right direction became much clearer. Instead of designing a better popover, I designed around the structure the product already had.
 
-<div class="flex flex-col items-stretch gap-10 sm:flex-row">
+<div class="flex flex-col items-stretch gap-10 pb-10 sm:flex-row">
   <LightboxImage
     src="/projects/ping/solution-old.png"
     alt="The old account settings page, listing notifications in a plain table"

--- a/src/content/projects/watchtower.mdx
+++ b/src/content/projects/watchtower.mdx
@@ -57,7 +57,7 @@ The goal wasn’t to just surface more infrastructure data. It was to translate 
 
 It also meant contributing across design and implementation.
 
-<div class="flex flex-col items-stretch gap-10 sm:flex-row">
+<div class="flex flex-col items-stretch gap-10 pb-10 sm:flex-row">
     <div class="flex-1">
         <p class="text-sm text-gray-400 mb-2">The previous monitoring tab</p>
         <LightboxImage

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -61,7 +61,9 @@ const {
     }
     <slot name="head" />
   </head>
-  <body class="bg-portfolio-page flex min-h-screen flex-col pt-16 font-mono">
+  <body
+    class="bg-portfolio-page flex min-h-screen flex-col overflow-x-hidden pt-16 font-mono"
+  >
     <div class="flex-1">
       <slot />
     </div>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -225,6 +225,11 @@ const Icon = icon;
   <Lightbox />
 </BaseLayout>
 
+<script>
+  import { observeGridReveal } from "@/lib/animations";
+  observeGridReveal();
+</script>
+
 <style>
   /* MDX content comes from a separately-compiled component tree (rendered via
      <Content /> in [slug].astro), so Astro's default *scoped* styles never
@@ -312,12 +317,118 @@ const Icon = icon;
 
   /* "The approach" gets the same left/right inset, matching "The problem"
      above — vertical padding stays on the fixed --ping-section-gap for
-     the same reason. */
+     the same reason. position: relative gives the ::after grid layer
+     below a containing block to size itself against. Unlike "The problem",
+     this section stays borderless/full-bleed on purpose — the border is
+     what marks Problem as the one "card" section, and adding one here
+     would blur that distinction. No overflow: hidden here (unlike the
+     original version of this rule) — the ::after grid layer below is
+     deliberately wider than this section's own box (it bleeds 40px past
+     the left/right edges), and clipping at the section boundary would
+     hide exactly that bleed. The page-level overflow-x-hidden on <body>
+     (BaseLayout.astro) is what stops that bleed from ever causing a
+     horizontal scrollbar on narrow viewports. */
   .article-body :global(.ping-section--approach) {
+    position: relative;
     padding-top: var(--ping-section-gap);
     padding-bottom: var(--ping-section-gap);
     padding-left: var(--ping-card-padding);
     padding-right: var(--ping-card-padding);
+  }
+
+  /* Decorative grid-line background for "The approach", inspired by
+     aphera.co's feature-section treatment. Two repeating-linear-gradients
+     (one per axis) draw 1px hairlines every 20px using the same weak
+     --section-border-color hairline already used for "The problem"'s
+     outline, so it reads as part of this design system rather than a
+     borrowed effect. (A per-project accent-color tint was tried here and
+     reverted — read as too loud/colorful for this background texture even
+     at 25% strength; the neutral hairline color works better.)
+     Deliberately ::after, not ::before: generated content always paints
+     after an element's real children by spec, so ::after guarantees this
+     stays behind the section's images/copy without depending on z-index
+     stacking order against the LightboxImage markup (which has its own
+     position: relative wrapper). The negative z-index below is
+     belt-and-suspenders on top of that. Also inert to pointer/click
+     interaction. Starts fully transparent — observeGridReveal()
+     (src/lib/animations.ts) adds .grid-active via IntersectionObserver
+     once the section scrolls into view, which is what actually plays the
+     gridSequence fade (defined in global.css). */
+  .article-body :global(.ping-section--approach::after) {
+    content: "";
+    position: absolute;
+    /* Bleeds the grid 40px past the section's own left/right edges (top/bottom
+       stay flush) so it reads as wider than the text column above it, similar
+       to aphera.co's reference. This section has no overflow: hidden of its
+       own (unlike "The problem"/"The solution") specifically so this bleed
+       isn't clipped — the page-level overflow-x-hidden on <body>
+       (BaseLayout.astro) is what stops it from ever causing a horizontal
+       scrollbar on narrow viewports instead. */
+    inset: 0 -40px;
+    background-image:
+      repeating-linear-gradient(
+        90deg,
+        transparent 0,
+        transparent 19px,
+        var(--section-border-color) 19px,
+        transparent 20px,
+        transparent 40px
+      ),
+      repeating-linear-gradient(
+        0deg,
+        transparent 0,
+        transparent 19px,
+        var(--section-border-color) 19px,
+        transparent 20px,
+        transparent 40px
+      );
+    /* Fades the grid out near all four edges instead of cutting off hard
+       — two gradients (one per axis) multiplied together via
+       mask-composite: intersect, so a point only stays fully opaque where
+       BOTH the horizontal and vertical fade are opaque (i.e. away from
+       every edge at once). -webkit- variants are Safari's still-required
+       prefixed equivalents (mask-composite ergo is broadly supported
+       unprefixed now, but -webkit-mask-composite uses different keyword
+       values, hence "source-in" there vs "intersect" above). */
+    mask-image:
+      linear-gradient(
+        to right,
+        transparent 0%,
+        rgba(0, 0, 0, 1) 10%,
+        rgba(0, 0, 0, 1) 90%,
+        transparent 100%
+      ),
+      linear-gradient(
+        to bottom,
+        transparent 0%,
+        rgba(0, 0, 0, 1) 10%,
+        rgba(0, 0, 0, 1) 90%,
+        transparent 100%
+      );
+    mask-composite: intersect;
+    -webkit-mask-image:
+      linear-gradient(
+        to right,
+        transparent 0%,
+        rgba(0, 0, 0, 1) 10%,
+        rgba(0, 0, 0, 1) 90%,
+        transparent 100%
+      ),
+      linear-gradient(
+        to bottom,
+        transparent 0%,
+        rgba(0, 0, 0, 1) 10%,
+        rgba(0, 0, 0, 1) 90%,
+        transparent 100%
+      );
+    -webkit-mask-composite: source-in;
+    pointer-events: none;
+    z-index: -1;
+    opacity: 0;
+  }
+
+  .article-body :global(.ping-section--approach.grid-active::after) {
+    animation: gridSequence 1.4s ease-out forwards;
   }
 
   /* "The solution" gets a translucent border and a subtle vertical-fade

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -336,14 +336,16 @@ const Icon = icon;
     padding-right: var(--ping-card-padding);
   }
 
-  /* Decorative grid-line background for "The approach", inspired by
-     aphera.co's feature-section treatment. Two repeating-linear-gradients
-     (one per axis) draw 1px hairlines every 20px using the same weak
+  /* Decorative dot-grid background for "The approach". A single tiled
+     radial-gradient draws a 1px dot every 24px using the same weak
      --section-border-color hairline already used for "The problem"'s
      outline, so it reads as part of this design system rather than a
-     borrowed effect. (A per-project accent-color tint was tried here and
-     reverted — read as too loud/colorful for this background texture even
-     at 25% strength; the neutral hairline color works better.)
+     borrowed effect. (An earlier version of this used a two-axis
+     repeating-linear-gradient line grid, matching aphera.co's reference;
+     swapped to dots after finding a closer reference. A per-project
+     accent-color tint was also tried and reverted — read as too loud/
+     colorful for this background texture even at 25% strength; the
+     neutral hairline color works better.)
      Deliberately ::after, not ::before: generated content always paints
      after an element's real children by spec, so ::after guarantees this
      stays behind the section's images/copy without depending on z-index
@@ -365,23 +367,16 @@ const Icon = icon;
        (BaseLayout.astro) is what stops it from ever causing a horizontal
        scrollbar on narrow viewports instead. */
     inset: 0 -40px;
-    background-image:
-      repeating-linear-gradient(
-        90deg,
-        transparent 0,
-        transparent 19px,
-        var(--section-border-color) 19px,
-        transparent 20px,
-        transparent 40px
-      ),
-      repeating-linear-gradient(
-        0deg,
-        transparent 0,
-        transparent 19px,
-        var(--section-border-color) 19px,
-        transparent 20px,
-        transparent 40px
-      );
+    /* "1px, transparent 1px" (not "0, transparent 1px") is what makes a
+       crisp dot instead of a soft blurred blob — the color stays solid from
+       center out to the 1px radius, then cuts hard to transparent at that
+       same radius. */
+    background-image: radial-gradient(
+      circle,
+      var(--section-border-color) 1px,
+      transparent 1px
+    );
+    background-size: 24px 24px;
     /* Fades the grid out near all four edges instead of cutting off hard
        — two gradients (one per axis) multiplied together via
        mask-composite: intersect, so a point only stays fully opaque where

--- a/src/lib/animations.ts
+++ b/src/lib/animations.ts
@@ -21,3 +21,34 @@ export function runFadeUpStagger(selector = "[data-animate]") {
     { duration: 0.5, delay: stagger(0.06), ease: [0.22, 1, 0.36, 1] },
   );
 }
+
+// Triggers the "Approach" section's grid background (see
+// .ping-section--approach::before in ProjectLayout.astro) once the section
+// scrolls into view, by adding a .grid-active class the CSS keyframe
+// (gridSequence, in global.css) is keyed off of.
+export function observeGridReveal(selector = ".ping-section--approach") {
+  const elements = document.querySelectorAll<HTMLElement>(selector);
+  if (elements.length === 0) return;
+
+  if (prefersReducedMotion()) {
+    elements.forEach((el) => {
+      el.classList.add("grid-active");
+    });
+    return;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+        entry.target.classList.add("grid-active");
+        // Fire once per page view — don't replay the fade if the reader
+        // scrolls back past this section again.
+        obs.unobserve(entry.target);
+      }
+    },
+    { threshold: 0.2 },
+  );
+
+  elements.forEach((el) => observer.observe(el));
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -339,3 +339,16 @@
     clip-path: inset(0 0 0 0);
   }
 }
+
+/* Approach section's scroll-triggered grid background (see
+   .ping-section--approach::before in ProjectLayout.astro) — a plain
+   opacity fade, played once when the section's .grid-active class is
+   added by observeGridReveal() in src/lib/animations.ts. */
+@keyframes gridSequence {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a scroll-triggered decorative grid background to "The approach" section on project case-study pages, revealed via IntersectionObserver once the section scrolls into view (respects `prefers-reduced-motion`).
- Grid is a dot pattern (single tiled `radial-gradient`), bleeding 40px past the section's left/right edges with a soft edge-fade mask, using the site's existing `--section-border-color` hairline token so it matches both themes.
- Second commit swaps an initial line-grid pass for the dot pattern after finding a closer visual reference — this is a first pass and dot spacing/opacity will likely need further tuning.

## Test plan
- [ ] `bun run dev`, visit `/projects/ping`, `/projects/undercurrent`, `/projects/watchtower` — confirm grid fades in once Approach scrolls into view, doesn't replay on scroll back
- [ ] Toggle light/dark theme — grid should follow `--section-border-color`
- [ ] Emulate `prefers-reduced-motion: reduce` — grid should appear immediately, no animation
- [ ] Resize to narrow viewport — confirm no horizontal scrollbar from the 40px bleed
- [ ] `bun run lint` / `bun run format:check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)